### PR TITLE
Updated to FodyCecil 2.0.7 from 1.29.4, which updates the Mono.Cecil …

### DIFF
--- a/MethodBoundaryAspect.Fody.UnitTests/MethodBoundaryAspect.Fody.UnitTests.csproj
+++ b/MethodBoundaryAspect.Fody.UnitTests/MethodBoundaryAspect.Fody.UnitTests.csproj
@@ -49,20 +49,20 @@
       <HintPath>..\packages\FluentAssertions.4.10.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.dll</HintPath>
+    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.7\lib\net40\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.7\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.7\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.7\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.core">

--- a/MethodBoundaryAspect.Fody.UnitTests/packages.config
+++ b/MethodBoundaryAspect.Fody.UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="4.10.0" targetFramework="net45" />
-  <package id="FodyCecil" version="1.29.4" targetFramework="net45" developmentDependency="true" />
+  <package id="FodyCecil" version="2.0.7" targetFramework="net45" developmentDependency="true" />
   <package id="NUnitTestAdapter.WithFramework" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/MethodBoundaryAspect.Fody/FolderAssemblyResolver.cs
+++ b/MethodBoundaryAspect.Fody/FolderAssemblyResolver.cs
@@ -43,5 +43,10 @@ namespace MethodBoundaryAspect.Fody
         {
             throw new NotImplementedException();
         }
-    }
+
+		public void Dispose()
+		{
+			_defaultAssemblyResolver.Dispose();
+		}
+	}
 }

--- a/MethodBoundaryAspect.Fody/InstructionBlockChainCreator.cs
+++ b/MethodBoundaryAspect.Fody/InstructionBlockChainCreator.cs
@@ -35,8 +35,7 @@ namespace MethodBoundaryAspect.Fody
         {
             //  argument values
             var argumentsTypeReference = _referenceFinder.GetTypeReference(typeof (object[]));
-            var argumentsArrayVariable = _creator.CreateVariable(CreateVariableName("arguments"),
-                argumentsTypeReference);
+            var argumentsArrayVariable = _creator.CreateVariable(argumentsTypeReference);
             var createObjectArrayWithMethodArgumentsBlock =
                 _creator.CreateObjectArrayWithMethodArguments(argumentsArrayVariable,
                     _referenceFinder.GetTypeReference(typeof (object)));
@@ -50,16 +49,15 @@ namespace MethodBoundaryAspect.Fody
         public NamedInstructionBlockChain CreateMethodExecutionArgsInstance(NamedInstructionBlockChain argumentsArrayChain)
         {
             // instance value
-            var instanceVariable = _creator.CreateVariable(CreateVariableName("this"), _method.DeclaringType);
+            var instanceVariable = _creator.CreateVariable(_method.DeclaringType);
             var createThisVariableBlock = _creator.CreateThisVariable(instanceVariable, _method.DeclaringType);
             
             // MethodExecutionArgs instance
             var onEntryMethodTypeRef =
                 _aspectTypeDefinition.Resolve().BaseType.Resolve().Methods.Single(x => x.Name == "OnEntry");
             var firstParameterType = onEntryMethodTypeRef.Parameters.Single().ParameterType;
-            var methodExecutionArgsTypeRef = _moduleDefinition.Import(firstParameterType);
-            var methodExecutionArgsVariable = _creator.CreateVariable(CreateVariableName("methodExecutionArgs"),
-                methodExecutionArgsTypeRef);
+            var methodExecutionArgsTypeRef = _moduleDefinition.ImportReference(firstParameterType);
+            var methodExecutionArgsVariable = _creator.CreateVariable(methodExecutionArgsTypeRef);
             var newObjectMethodExecutionArgsBlock = _creator.NewObject(
                 methodExecutionArgsVariable,
                 methodExecutionArgsTypeRef, 
@@ -81,7 +79,7 @@ namespace MethodBoundaryAspect.Fody
                 methodExecutionArgsSetArgumentsMethodRef, argumentsArrayChain.Variable);
 
             var methodBaseTypeRef = _referenceFinder.GetTypeReference(typeof (MethodBase));
-            var methodBaseVariable = _creator.CreateVariable(CreateVariableName("methodBase"), methodBaseTypeRef);
+            var methodBaseVariable = _creator.CreateVariable(methodBaseTypeRef);
             var methodBaseGetCurrentMethod = _referenceFinder.GetMethodReference(methodBaseTypeRef,
                 md => md.Name == "GetCurrentMethod");
             var callGetCurrentMethodBlock = _creator.CallStaticMethod(methodBaseGetCurrentMethod, methodBaseVariable);
@@ -108,8 +106,8 @@ namespace MethodBoundaryAspect.Fody
 
         public NamedInstructionBlockChain CreateAspectInstance(CustomAttribute aspect)
         {
-            var aspectTypeReference = _moduleDefinition.Import(_aspectTypeDefinition);
-            var aspectVariable = _creator.CreateVariable(CreateVariableName("aspect"), aspectTypeReference);
+            var aspectTypeReference = _moduleDefinition.ImportReference(_aspectTypeDefinition);
+            var aspectVariable = _creator.CreateVariable(aspectTypeReference);
             var newObjectAspectBlock = _creator.NewObject(aspectVariable, aspectTypeReference, _moduleDefinition, aspect, _aspectCounter);
 
             var newObjectAspectBlockChain = new NamedInstructionBlockChain(aspectVariable, aspectTypeReference);
@@ -138,7 +136,7 @@ namespace MethodBoundaryAspect.Fody
             NamedInstructionBlockChain createMethodExecutionArgsInstance)
         {
             var exceptionTypeRef = _referenceFinder.GetTypeReference(typeof (Exception));
-            var exceptionVariable = _creator.CreateVariable(CreateVariableName("exception"), exceptionTypeRef);
+            var exceptionVariable = _creator.CreateVariable(exceptionTypeRef);
             var assignExceptionVariable = _creator.AssignValueFromStack(exceptionVariable);
 
             var methodExecutionArgsSetExceptionMethodRef =
@@ -169,7 +167,7 @@ namespace MethodBoundaryAspect.Fody
             if (!_creator.HasReturnValue())
                 return new NamedInstructionBlockChain(null, _method.ReturnType);
 
-            var returnValueVariable = _creator.CreateVariable(CreateVariableName("returnValue"), _method.ReturnType);
+            var returnValueVariable = _creator.CreateVariable(_method.ReturnType);
             var block = new NamedInstructionBlockChain(returnValueVariable, _method.ReturnType);
 
             var instructions = _creator.SaveReturnValueFromStack(returnValueVariable);
@@ -184,7 +182,7 @@ namespace MethodBoundaryAspect.Fody
             if (!_creator.HasThrowAsReturn())
                 return new NamedInstructionBlockChain(null, exceptionTypeRef);
 
-            var exceptionVariable = _creator.CreateVariable(CreateVariableName("thrownException"), exceptionTypeRef);
+            var exceptionVariable = _creator.CreateVariable(exceptionTypeRef);
             var block = new NamedInstructionBlockChain(exceptionVariable, exceptionTypeRef);
 
             var instructions = _creator.AssignValueFromStack(exceptionVariable);

--- a/MethodBoundaryAspect.Fody/InstructionBlockCreator.cs
+++ b/MethodBoundaryAspect.Fody/InstructionBlockCreator.cs
@@ -32,12 +32,12 @@ namespace MethodBoundaryAspect.Fody
             return _method.Body.Instructions.Last().OpCode.Code == Code.Throw;
         }
 
-        public VariableDefinition CreateVariable(string variableName, TypeReference variableTypeReference)
+        public VariableDefinition CreateVariable(TypeReference variableTypeReference)
         {
             if (IsVoid(variableTypeReference))
                 throw new InvalidOperationException("Variable of type 'Void' is not possible!");
 
-            var variableDefinition = new VariableDefinition(variableName, variableTypeReference);
+            var variableDefinition = new VariableDefinition(variableTypeReference);
             _method.Body.Variables.Add(variableDefinition);
             return variableDefinition;
         }
@@ -132,7 +132,7 @@ namespace MethodBoundaryAspect.Fody
                     var propertyCopy = property;
 
                     var loadOnStackInstruction = LoadValueOnStack(propertyCopy.Argument.Type, propertyCopy.Argument.Value, module);
-                    var valueVariable = CreateVariable(CreateVariableName("namedArgument", aspectCounter, namedArgumentCounter), propertyCopy.Argument.Type);
+                    var valueVariable = CreateVariable(propertyCopy.Argument.Type);
                     var assignVariableInstructionBlock = AssignValueFromStack(valueVariable);
 
                     var methodRef = _referenceFinder.GetMethodReference(instanceTypeReference, md => md.Name == "set_" + propertyCopy.Name);

--- a/MethodBoundaryAspect.Fody/MethodBoundaryAspect.Fody.csproj
+++ b/MethodBoundaryAspect.Fody/MethodBoundaryAspect.Fody.csproj
@@ -43,20 +43,20 @@
     <AssemblyOriginatorKeyFile>MethodBoundaryAspect.Fody.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.dll</HintPath>
+    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.7\lib\net40\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.7\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.7\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.7\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/MethodBoundaryAspect.Fody/MethodBoundaryAspect.Fody.nuspec
+++ b/MethodBoundaryAspect.Fody/MethodBoundaryAspect.Fody.nuspec
@@ -13,8 +13,8 @@
     <copyright>VESCON GmbH 2016</copyright>
     <tags>ILWeaving Fody Aspect AOP Method Invocation MethodBoundary</tags>
     <dependencies>
-      <dependency id="Fody" version="1.29.4"/>
-      <dependency id="FodyCecil" version="1.29.4"/>
+      <dependency id="Fody" version="2.0.7" />
+      <dependency id="FodyCecil" version="2.0.7"/>
     </dependencies>
   </metadata>
   <files>

--- a/MethodBoundaryAspect.Fody/ModuleWeaver.cs
+++ b/MethodBoundaryAspect.Fody/ModuleWeaver.cs
@@ -93,22 +93,25 @@ namespace MethodBoundaryAspect.Fody
             var readerParameters = new ReaderParameters
             {
                 ReadSymbols = true,
-                SymbolReaderProvider = new PdbReaderProvider()
+                SymbolReaderProvider = new PdbReaderProvider(),
+				ReadWrite = true,
             };
 
             if (AdditionalAssemblyResolveFolders.Any())
                 readerParameters.AssemblyResolver = new FolderAssemblyResolver(AdditionalAssemblyResolveFolders);
-            var assemblyDefinition = AssemblyDefinition.ReadAssembly(assemblyPath, readerParameters);
 
-            var module = assemblyDefinition.MainModule;
-            Execute(module);
+			using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(assemblyPath, readerParameters))
+			{
+				var module = assemblyDefinition.MainModule;
+				Execute(module);
 
-            var writerParameters = new WriterParameters
-            {
-                WriteSymbols = true,
-                SymbolWriterProvider = new PdbWriterProvider()
-            };
-            assemblyDefinition.Write(assemblyPath, writerParameters);
+				var writerParameters = new WriterParameters
+				{
+					WriteSymbols = true,
+					SymbolWriterProvider = new PdbWriterProvider()
+				};
+				assemblyDefinition.Write(writerParameters);
+			}
         }
 
         public void AddClassFilter(string classFilter)

--- a/MethodBoundaryAspect.Fody/packages.config
+++ b/MethodBoundaryAspect.Fody/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CreateNewNuGetPackageFromProjectAfterEachBuild" version="1.8.9" targetFramework="net45" developmentDependency="true" />
-  <package id="FodyCecil" version="1.29.4" targetFramework="net45" developmentDependency="true" />
+  <package id="FodyCecil" version="2.0.7" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
…version from 0.9.6.0 to 0.10.0.0. Addresses breaking changes to Cecil mentioned at http://cecil.pe/ regarding IDisposable on a few types, and some adjustments to the ReaderParameters in ModuleWeaver to account for new file IO changes in Cecil. Variable Name was also a breaking change in Cecil, so I removed it.