### PR TITLE
rethrow exception instead of explicitly throwing the same exception. …

### DIFF
--- a/src/MethodBoundaryAspect.Fody/MethodWeaver.cs
+++ b/src/MethodBoundaryAspect.Fody/MethodWeaver.cs
@@ -321,7 +321,7 @@ namespace MethodBoundaryAspect.Fody
 
             afterThrowChain.Add(new InstructionBlock("Leave", Instruction.Create(OpCodes.Leave_S, realInstructionAfterCall)));
             flowBehaviorHandler.Add(new InstructionBlock("If == then skip throw", Instruction.Create(OpCodes.Beq_S, afterThrowChain.First)));
-            flowBehaviorHandler.Add(new InstructionBlock("throw", _creator.LoadValueOnStack(exception).Flatten().Instructions.Concat(new[] { Instruction.Create(OpCodes.Throw) } ).ToArray()));
+            flowBehaviorHandler.Add(new InstructionBlock("throw", Instruction.Create(OpCodes.Rethrow)));
             flowBehaviorHandler.Add(afterThrowChain);
             flowBehaviorHandler.InsertAfter(exceptionHandlerCurrent, _ilProcessor);
 


### PR DESCRIPTION
This fixes Microsoft.Usage CA2200 RethrowToPreserveStackDetails warning (or error, depending on code analysis settings). Also preserves stack trace for exception, as is stated on the warning description page jn MSDN.
Also PostSharp does exactly that.