### PR TITLE
Added new attribute 'AspectOrderIndexAttribute' to define the execution order of multiple aspects

### DIFF
--- a/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/Aspect1.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/Aspect1.cs
@@ -1,0 +1,19 @@
+﻿using MethodBoundaryAspect.Fody.Attributes;
+
+namespace MethodBoundaryAspect.Fody.UnitTests.NetFramework.MultipleAspects
+{
+    [ProvideAspectRole(TestRoles.First)]
+    public class Aspect1 : OnMethodBoundaryAspect
+    {
+        public override void OnEntry(MethodExecutionArgs arg)
+        {
+            MultipleAspectsWithOrderIndexMethods.Result += "[Aspect1_OnEntry]";
+            arg.MethodExecutionTag = "[Aspect1_OnExit]";
+        }
+
+        public override void OnExit(MethodExecutionArgs arg)
+        {
+            MultipleAspectsWithOrderIndexMethods.Result += arg.MethodExecutionTag;
+        }
+    }
+}

--- a/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/Aspect2.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/Aspect2.cs
@@ -1,0 +1,19 @@
+﻿using MethodBoundaryAspect.Fody.Attributes;
+
+namespace MethodBoundaryAspect.Fody.UnitTests.NetFramework.MultipleAspects
+{
+    [ProvideAspectRole(TestRoles.Second)]
+    public class Aspect2 : OnMethodBoundaryAspect
+    {
+        public override void OnEntry(MethodExecutionArgs arg)
+        {
+            MultipleAspectsWithOrderIndexMethods.Result += "[Aspect2_OnEntry]";
+            arg.MethodExecutionTag = "[Aspect2_OnExit]";
+        }
+
+        public override void OnExit(MethodExecutionArgs arg)
+        {
+            MultipleAspectsWithOrderIndexMethods.Result += arg.MethodExecutionTag;
+        }
+    }
+}

--- a/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/Aspect3.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/Aspect3.cs
@@ -1,0 +1,19 @@
+﻿using MethodBoundaryAspect.Fody.Attributes;
+
+namespace MethodBoundaryAspect.Fody.UnitTests.NetFramework.MultipleAspects
+{
+    [ProvideAspectRole(TestRoles.Third)]
+    public class Aspect3 : OnMethodBoundaryAspect
+    {
+        public override void OnEntry(MethodExecutionArgs arg)
+        {
+            MultipleAspectsWithOrderIndexMethods.Result += "[Aspect3_OnEntry]";
+            arg.MethodExecutionTag = "[Aspect3_OnExit]";
+        }
+
+        public override void OnExit(MethodExecutionArgs arg)
+        {
+            MultipleAspectsWithOrderIndexMethods.Result += arg.MethodExecutionTag;
+        }
+    }
+}

--- a/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/FailTests/RoleAndSameOrderingAspect.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/FailTests/RoleAndSameOrderingAspect.cs
@@ -3,7 +3,9 @@ using MethodBoundaryAspect.Fody.Attributes;
 namespace MethodBoundaryAspect.Fody.UnitTests.NetFramework.MultipleAspects.FailTests
 {
     [ProvideAspectRole(TestRoles.Third)]
+#pragma warning disable 0618
     [AspectRoleDependency(AspectDependencyAction.Order, AspectDependencyPosition.Before, TestRoles.Third)]
+#pragma warning restore 0618
     public class RoleAndSameOrderingAspect : OnMethodBoundaryAspect
     {
     }

--- a/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/FirstAspect.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/FirstAspect.cs
@@ -5,7 +5,9 @@ using MethodBoundaryAspect.Fody.Attributes;
 namespace MethodBoundaryAspect.Fody.UnitTests.NetFramework.MultipleAspects
 {
     [ProvideAspectRole(TestRoles.First)]
+#pragma warning disable 0618
     [AspectRoleDependency(AspectDependencyAction.Order, AspectDependencyPosition.Before, TestRoles.Second)]
+#pragma warning restore 0618
     public class FirstAspect : OnMethodBoundaryAspect
     {
         private const string MethodExecutionTagValue = TestRoles.First;

--- a/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/MultipleAspectsWithOrderIndexMethods.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/MultipleAspectsWithOrderIndexMethods.cs
@@ -1,0 +1,29 @@
+﻿using MethodBoundaryAspect.Fody.Attributes;
+
+namespace MethodBoundaryAspect.Fody.UnitTests.NetFramework.MultipleAspects
+{
+    [AspectOrderIndex(typeof(Aspect1), 3)]
+    [AspectOrderIndex(typeof(Aspect2), 2)]
+    [AspectOrderIndex(typeof(Aspect3), 1)]
+    public class MultipleAspectsWithOrderIndexMethods
+    {
+        public static string Result { get; set; }
+        
+        [Aspect1]
+        [Aspect2]
+        [Aspect3]
+        public void MethodWithOrderIndexSpecifiedOnClassLevel()
+        {
+        }
+
+        [Aspect1]
+        [Aspect2]
+        [Aspect3]
+        [AspectOrderIndex(typeof(Aspect1), 0)]
+        [AspectOrderIndex(typeof(Aspect2), -1)]
+        [AspectOrderIndex(typeof(Aspect3), 1)]
+        public void MethodWithOrderIndexSpecified()
+        {
+        }
+    }
+}

--- a/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/SecondAspect.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspects/SecondAspect.cs
@@ -5,7 +5,9 @@ using MethodBoundaryAspect.Fody.Attributes;
 namespace MethodBoundaryAspect.Fody.UnitTests.NetFramework.MultipleAspects
 {
     [ProvideAspectRole(TestRoles.Second)]
+#pragma warning disable 0618
     [AspectRoleDependency(AspectDependencyAction.Order, AspectDependencyPosition.After, TestRoles.First)]
+#pragma warning restore 0618
     public class SecondAspect : OnMethodBoundaryAspect
     {
         private const string MethodExecutionTagValue = TestRoles.Second;

--- a/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspectsWithOrderIndexTests.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/MultipleAspectsWithOrderIndexTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using FluentAssertions;
+using MethodBoundaryAspect.Fody.UnitTests.NetFramework.MultipleAspects;
+using Xunit;
+
+namespace MethodBoundaryAspect.Fody.UnitTests.NetFramework
+{
+    public class MultipleAspectsWithOrderIndexTests : MethodBoundaryAspectNetFrameworkTestBase
+    {
+        private static readonly Type TestClassType = typeof(MultipleAspectsWithOrderIndexMethods);
+
+        [Fact]
+        public void IMethodWithOrderIndexSpecifiedOnClassLevelIsCalled_ThenTheOnMethodBoundaryAspectsShouldBeCalledInCorrectOrder()
+        {
+            // Arrange
+            const string testMethodName = "MethodWithOrderIndexSpecifiedOnClassLevel";
+            WeaveAssemblyMethodAndLoad(TestClassType, testMethodName);
+
+            // Act
+            var result = AssemblyLoader.InvokeMethod(TestClassType.TypeInfo(), testMethodName);
+
+            // Assert
+            result.Should().Be("[Aspect3_OnEntry][Aspect2_OnEntry][Aspect1_OnEntry][Aspect1_OnExit][Aspect2_OnExit][Aspect3_OnExit]");
+        }
+
+        [Fact]
+        public void IfMethodWithOrderIndexSpecifiedIsCalled_ThenTheOnMethodBoundaryAspectsShouldBeCalledInCorrectOrder()
+        {
+            // Arrange
+            const string testMethodName = "MethodWithOrderIndexSpecified";
+            WeaveAssemblyMethodAndLoad(TestClassType, testMethodName);
+
+            // Act
+            var result = AssemblyLoader.InvokeMethod(TestClassType.TypeInfo(), testMethodName);
+
+            // Assert
+            result.Should().Be("[Aspect2_OnEntry][Aspect1_OnEntry][Aspect3_OnEntry][Aspect3_OnExit][Aspect1_OnExit][Aspect2_OnExit]");
+        }
+    }
+}

--- a/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.External/Aspects/ReturnValuePlusN.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.External/Aspects/ReturnValuePlusN.cs
@@ -3,7 +3,9 @@
 namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.External.Aspects
 {
     [ProvideAspectRole("Second")]
+#pragma warning disable 0618
     [AspectRoleDependency(AspectDependencyAction.Order, AspectDependencyPosition.After, "First")]
+#pragma warning restore 0618
     public class ReturnValuePlusN : OnMethodBoundaryAspect
     {
         int _n;

--- a/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.External/Aspects/ReturnValueTimesN.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.External/Aspects/ReturnValueTimesN.cs
@@ -3,7 +3,9 @@
 namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.External.Aspects
 {
     [ProvideAspectRole("First")]
+#pragma warning disable 0618
     [AspectRoleDependency(AspectDependencyAction.Order, AspectDependencyPosition.Before, "Second")]
+#pragma warning restore 0618
     public class ReturnValueTimesN : OnMethodBoundaryAspect
     {
         int _n;

--- a/src/MethodBoundaryAspect.Fody/AttributeFullNames.cs
+++ b/src/MethodBoundaryAspect.Fody/AttributeFullNames.cs
@@ -16,5 +16,8 @@
 
         public static string ProvideAspectRoleAttribute =>
             "MethodBoundaryAspect.Fody.Attributes.ProvideAspectRoleAttribute";
+
+        public static string AspectOrderIndexAttribute =>
+            "MethodBoundaryAspect.Fody.Attributes.AspectOrderIndexAttribute";
     }
 }

--- a/src/MethodBoundaryAspect.Fody/ModuleWeaver.cs
+++ b/src/MethodBoundaryAspect.Fody/ModuleWeaver.cs
@@ -204,7 +204,10 @@ namespace MethodBoundaryAspect.Fody
                     .ToList();
                 if (aspectInfos.Count == 0)
                     continue;
-                
+
+                foreach (var aspectInfo in aspectInfos)
+                    aspectInfo.InitOrderIndex(assemblyMethodBoundaryAspects, classMethodBoundaryAspects, methodMethodBoundaryAspects);
+
                 weavedAtLeastOneMethod = WeaveMethod(
                     module,
                     method,

--- a/src/MethodBoundaryAspect.Fody/Ordering/AspectInfo.cs
+++ b/src/MethodBoundaryAspect.Fody/Ordering/AspectInfo.cs
@@ -116,24 +116,23 @@ namespace MethodBoundaryAspect.Fody.Ordering
             IEnumerable<CustomAttribute> classAspectAttributes,
             IEnumerable<CustomAttribute> methodAspectAttributes)
         {
-            var aspectAttributes = new[] {assemblyAspectAttributes, classAspectAttributes, methodAspectAttributes};
+            InternalInitOrderIndex(assemblyAspectAttributes, "assembly");
+            InternalInitOrderIndex(classAspectAttributes, "class");
+            InternalInitOrderIndex(methodAspectAttributes, "method");
+        }
 
-            for (int i = 0; i < aspectAttributes.Length; i++)
-            {
-                var orderIndexAttributes = aspectAttributes[i]
+        private void InternalInitOrderIndex(IEnumerable<CustomAttribute> aspectAttributes, string level)
+        {
+            var orderIndexAttributes = aspectAttributes
                     .Where(c => c.AttributeType.FullName == AttributeFullNames.AspectOrderIndexAttribute &&
                                 ((TypeReference)c.ConstructorArguments[0].Value).FullName == AspectTypeDefinition.FullName)
                     .ToList();
 
-                if (orderIndexAttributes.Count > 1)
-                    throw new InvalidAspectConfigurationException(
-                        string.Format(AspectHasMultipleOrderIndicesDefinedOnTheSameLevel,
-                            Name,
-                            i == 0 ? "assembly" : i == 1 ? "class" : "method"));
+            if (orderIndexAttributes.Count > 1)
+                throw new InvalidAspectConfigurationException(string.Format(AspectHasMultipleOrderIndicesDefinedOnTheSameLevel, Name, level));
 
-                if (orderIndexAttributes.Count == 1)
-                    OrderIndex = (int)orderIndexAttributes[0].ConstructorArguments[1].Value;
-            }
+            if (orderIndexAttributes.Count == 1)
+                OrderIndex = (int)orderIndexAttributes[0].ConstructorArguments[1].Value;
         }
     }
 }

--- a/src/MethodBoundaryAspect.Fody/Ordering/AspectInfo.cs
+++ b/src/MethodBoundaryAspect.Fody/Ordering/AspectInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
@@ -9,21 +10,26 @@ namespace MethodBoundaryAspect.Fody.Ordering
         private const string AspectCanTHaveRoleAndBeOrderedBeforeOrAfterThatRole =
             "Aspect '{0}' can't have role '{1}' and be ordered before or after that role";
 
-        private const string AspectHasToProvideANonEmptyMethodboundaryaspectAttributesProvideaspectroleAttribute =
+        private const string AspectHasToProvideANonEmptyMethodBoundaryAspectAttributesProvideAspectRoleAttribute =
             "Aspect '{0}' has to provide a non-empty MethodBoundaryAspect.Attributes.ProvideAspectRoleAttribute attribute";
+
+        private const string AspectHasMultipleOrderIndicesDefinedOnTheSameLevel =
+            "Aspect '{0}' has multiple order indices defined on {1} level";
 
         public AspectInfo(CustomAttribute aspectAttribute)
         {
             AspectAttribute = aspectAttribute;
             Name = aspectAttribute.AttributeType.FullName;
-            var aspectType = aspectAttribute.AttributeType.Resolve();
+            AspectTypeDefinition = aspectAttribute.AttributeType.Resolve();
 
-            var aspectAttributes = aspectType.CustomAttributes;
+            var aspectAttributes = AspectTypeDefinition.CustomAttributes;
             InitRole(aspectAttributes);
             InitOrder(aspectAttributes);
             InitSkipProperties(aspectAttributes);
         }
         
+        public TypeDefinition AspectTypeDefinition { get; }
+
         public string Name { get; private set; }
 
         public string Role { get; private set; }
@@ -34,7 +40,11 @@ namespace MethodBoundaryAspect.Fody.Ordering
 
         public List<CustomAttribute> AspectRoleDependencyAttributes { get; private set; }
 
+#pragma warning disable 0618
         public AspectOrder Order { get; private set; }
+#pragma warning restore 0618
+
+        public int? OrderIndex { get; set; }
 
         private void InitRole(IEnumerable<CustomAttribute> aspectAttributes)
         {
@@ -50,7 +60,7 @@ namespace MethodBoundaryAspect.Fody.Ordering
             if (string.IsNullOrEmpty(role))
             {
                 var msg =
-                    string.Format(AspectHasToProvideANonEmptyMethodboundaryaspectAttributesProvideaspectroleAttribute,
+                    string.Format(AspectHasToProvideANonEmptyMethodBoundaryAspectAttributesProvideAspectRoleAttribute,
                         Name);
                 throw new InvalidAspectConfigurationException(msg);
             }
@@ -67,7 +77,10 @@ namespace MethodBoundaryAspect.Fody.Ordering
             if (AspectRoleDependencyAttributes.Count == 0)
                 return;
 
+#pragma warning disable 0618
             var aspectOrder = new AspectOrder(this);
+#pragma warning restore 0618
+
             foreach (var roleDependencyAttribute in AspectRoleDependencyAttributes)
             {
                 var role = (string) roleDependencyAttribute.ConstructorArguments[2].Value;
@@ -96,6 +109,31 @@ namespace MethodBoundaryAspect.Fody.Ordering
             var skipProperties = (bool)skipPropertiesAttribute.ConstructorArguments[0].Value;
 
             SkipProperties = skipProperties;
+        }
+
+        public void InitOrderIndex(
+            IEnumerable<CustomAttribute> assemblyAspectAttributes,
+            IEnumerable<CustomAttribute> classAspectAttributes,
+            IEnumerable<CustomAttribute> methodAspectAttributes)
+        {
+            var aspectAttributes = new[] {assemblyAspectAttributes, classAspectAttributes, methodAspectAttributes};
+
+            for (int i = 0; i < aspectAttributes.Length; i++)
+            {
+                var orderIndexAttributes = aspectAttributes[i]
+                    .Where(c => c.AttributeType.FullName == AttributeFullNames.AspectOrderIndexAttribute &&
+                                ((TypeReference)c.ConstructorArguments[0].Value).FullName == AspectTypeDefinition.FullName)
+                    .ToList();
+
+                if (orderIndexAttributes.Count > 1)
+                    throw new InvalidAspectConfigurationException(
+                        string.Format(AspectHasMultipleOrderIndicesDefinedOnTheSameLevel,
+                            Name,
+                            i == 0 ? "assembly" : i == 1 ? "class" : "method"));
+
+                if (orderIndexAttributes.Count == 1)
+                    OrderIndex = (int)orderIndexAttributes[0].ConstructorArguments[1].Value;
+            }
         }
     }
 }

--- a/src/MethodBoundaryAspect.Fody/Ordering/AspectOrderer.cs
+++ b/src/MethodBoundaryAspect.Fody/Ordering/AspectOrderer.cs
@@ -12,6 +12,7 @@ namespace MethodBoundaryAspect.Fody.Ordering
                 .Where(x => x.AspectRoleDependencyAttributes.Count > 0)
                 .ToList();
 
+            // if AspectDependencyAction.Order is not used, use AspectOrderIndexAttribute
             if (aspectInfosWithOrderAttributes.Count == 0)
                 return OrderInternalByOrderIndex(aspectInfos);
 

--- a/src/MethodBoundaryAspect/Attributes/AspectDependencyAction.cs
+++ b/src/MethodBoundaryAspect/Attributes/AspectDependencyAction.cs
@@ -1,5 +1,8 @@
+using System;
+
 namespace MethodBoundaryAspect.Fody.Attributes
 {
+    [Obsolete("Use AspectOrderIndexAttribute to define the execution order of multiple aspects.")]
     public enum AspectDependencyAction
     {
         None,

--- a/src/MethodBoundaryAspect/Attributes/AspectDependencyPosition.cs
+++ b/src/MethodBoundaryAspect/Attributes/AspectDependencyPosition.cs
@@ -1,5 +1,8 @@
+using System;
+
 namespace MethodBoundaryAspect.Fody.Attributes
 {
+    [Obsolete("Use AspectOrderIndexAttribute to define the execution order of multiple aspects.")]
     public enum AspectDependencyPosition
     {
         Before = -1,

--- a/src/MethodBoundaryAspect/Attributes/AspectOrderIndexAttribute.cs
+++ b/src/MethodBoundaryAspect/Attributes/AspectOrderIndexAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace MethodBoundaryAspect.Fody.Attributes
+{
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+    public class AspectOrderIndexAttribute : Attribute
+    {
+        public AspectOrderIndexAttribute(
+            Type aspectType,
+            int orderIndex)
+        {
+            AspectType = aspectType;
+            OrderIndex = orderIndex;
+        }
+
+        public Type AspectType { get;  }
+        public int OrderIndex { get; }
+    }
+}

--- a/src/MethodBoundaryAspect/Attributes/AspectRoleDependencyAttribute.cs
+++ b/src/MethodBoundaryAspect/Attributes/AspectRoleDependencyAttribute.cs
@@ -2,6 +2,7 @@
 
 namespace MethodBoundaryAspect.Fody.Attributes
 {
+    [Obsolete("Use AspectOrderIndexAttribute to define the execution order of multiple aspects.")]
     public class AspectRoleDependencyAttribute : Attribute
     {
         public AspectRoleDependencyAttribute(


### PR DESCRIPTION
The attributes 'AspectRoleDependencyAttribute' , 'AspectDependencyAction' and 'AspectDependencyPosition' are now obsolete, because they only support ordering of 2 aspects.