### PR TITLE
implemented using modified args array when executing method body

### DIFF
--- a/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/ClassChangeInputArgumentAspectTests.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/ClassChangeInputArgumentAspectTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using FluentAssertions;
+using MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework;
+using Xunit;
+
+namespace MethodBoundaryAspect.Fody.UnitTests.NetFramework
+{
+    public class ClassChangeInputArgumentAspectTests : MethodBoundaryAspectNetFrameworkTestBase
+    {
+        private static readonly Type TestMethodsType = typeof (ChangeInputArgumentAspectMethods);
+        
+        [Fact]
+        public void IfStaticMethodIsCalled_ThenTheOnMethodBoundaryAspectShouldBeCalled()
+        {
+            // Arrange
+            const string testMethodName = "StaticMethodCallFirstArgument";
+            WeaveAssemblyMethodAndLoad(TestMethodsType, testMethodName);
+
+            // Act
+            var result = AssemblyLoader.InvokeMethod(TestMethodsType.TypeInfo(), testMethodName, 99);
+
+            // Assert
+            result.Should().Be(42);
+        }
+
+        [Fact]
+        public void IfInstanceMethodIsCalled_ThenTheOnMethodBoundaryAspectShouldBeCalled()
+        {
+            // Arrange
+            const string testMethodName = "InstanceMethodCallSecondArgument";
+            WeaveAssemblyMethodAndLoad(TestMethodsType, testMethodName);
+
+            // Act
+            var result = AssemblyLoader.InvokeMethod(TestMethodsType.TypeInfo(), testMethodName, 99, 999);
+
+            // Assert
+            result.Should().Be("42");
+        }
+    }
+}

--- a/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/ClassChangeInputArgumentAspectTests.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/ClassChangeInputArgumentAspectTests.cs
@@ -36,5 +36,24 @@ namespace MethodBoundaryAspect.Fody.UnitTests.NetFramework
             // Assert
             result.Should().Be("42");
         }
+        
+        [Fact]
+        public void IfInstanceMethodWithRefArgumentIsCalled_ThenTheOnMethodBoundaryAspectShouldBeCalled()
+        {
+            // Arrange
+            const string testMethodName = "InstanceMethodCallFirstArgumentArray";
+            WeaveAssemblyMethodAndLoad(TestMethodsType, testMethodName);
+
+            // Act
+            var result = AssemblyLoader.InvokeMethod(TestMethodsType.TypeInfo(), testMethodName, new TestData());
+
+            // Assert
+            result.Should().BeOfType<object[]>();
+        }
+
+        [Serializable]
+        private class TestData
+        {
+        }
     }
 }

--- a/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/ClassChangeInputArgumentAspectTests.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.NetFramework/ClassChangeInputArgumentAspectTests.cs
@@ -45,15 +45,25 @@ namespace MethodBoundaryAspect.Fody.UnitTests.NetFramework
             WeaveAssemblyMethodAndLoad(TestMethodsType, testMethodName);
 
             // Act
-            var result = AssemblyLoader.InvokeMethod(TestMethodsType.TypeInfo(), testMethodName, new TestData());
+            var result = AssemblyLoader.InvokeMethod(TestMethodsType.TypeInfo(), testMethodName, new object());
 
             // Assert
             result.Should().BeOfType<object[]>();
         }
 
-        [Serializable]
-        private class TestData
+        [Fact]
+        public void IfInstanceMethodWithAspectNotAllowedChangingInputArgumentsIsCalled_ThenTheOnMethodBoundaryAspectShouldBeCalled()
         {
+            // Arrange
+            const string testMethodName = "InstanceMethodCallNotAllowedChangingInputArguments";
+            WeaveAssemblyMethodAndLoad(TestMethodsType, testMethodName);
+
+            // Act
+            var guid = Guid.NewGuid();
+            var result = AssemblyLoader.InvokeMethod(TestMethodsType.TypeInfo(), testMethodName, guid);
+
+            // Assert
+            result.Should().Be(guid);
         }
     }
 }

--- a/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/Aspects/ChangeFirstInputArgumentToArrayAspect.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/Aspects/ChangeFirstInputArgumentToArrayAspect.cs
@@ -1,0 +1,12 @@
+﻿using MethodBoundaryAspect.Fody.Attributes;
+
+namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.Aspects
+{
+    public class ChangeFirstInputArgumentToArrayAspect : OnMethodBoundaryAspect
+    {
+        public override void OnEntry(MethodExecutionArgs arg)
+        {
+            arg.Arguments[0] = new object[10];
+        }
+    }
+}

--- a/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/Aspects/ChangeInputArgumentAspect.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/Aspects/ChangeInputArgumentAspect.cs
@@ -2,6 +2,7 @@
 
 namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.Aspects
 {
+    [AllowChangingInputArguments]
     public class ChangeInputArgumentAspect : OnMethodBoundaryAspect
     {
         public int Index { get; set; }

--- a/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/Aspects/ChangeInputArgumentAspect.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/Aspects/ChangeInputArgumentAspect.cs
@@ -1,0 +1,15 @@
+﻿using MethodBoundaryAspect.Fody.Attributes;
+
+namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.Aspects
+{
+    public class ChangeInputArgumentAspect : OnMethodBoundaryAspect
+    {
+        public int Index { get; set; }
+        public object Value { get; set; }
+
+        public override void OnEntry(MethodExecutionArgs arg)
+        {
+            arg.Arguments[Index] = Value;
+        }
+    }
+}

--- a/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/Aspects/ChangeInputArgumentsNotAllowedAspect.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/Aspects/ChangeInputArgumentsNotAllowedAspect.cs
@@ -2,12 +2,11 @@
 
 namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.Aspects
 {
-    [AllowChangingInputArguments]
-    public class ChangeFirstInputArgumentToArrayAspect : OnMethodBoundaryAspect
+    public class ChangeInputArgumentsNotAllowedAspect : OnMethodBoundaryAspect
     {
         public override void OnEntry(MethodExecutionArgs arg)
         {
-            arg.Arguments[0] = new object[10];
+            arg.Arguments[0] = "XXX";
         }
     }
 }

--- a/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/ChangeInputArgumentAspectMethods.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/ChangeInputArgumentAspectMethods.cs
@@ -17,5 +17,11 @@ namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework
         {
             Result = arg2;
         }
+        
+        [ChangeFirstInputArgumentToArrayAspect]
+        public void InstanceMethodCallFirstArgumentArray(ref object arg1)
+        {
+            Result = arg1;
+        }
     }
 }

--- a/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/ChangeInputArgumentAspectMethods.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/ChangeInputArgumentAspectMethods.cs
@@ -1,0 +1,21 @@
+﻿using MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.Aspects;
+
+namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework
+{
+    public class ChangeInputArgumentAspectMethods
+    {
+        public static object Result { get; set; }
+
+        [ChangeInputArgumentAspect(Index = 0, Value = 42)]
+        public static void StaticMethodCallFirstArgument(object arg1)
+        {
+            Result = arg1;
+        }
+
+        [ChangeInputArgumentAspect(Index = 1, Value = "42")]
+        public void InstanceMethodCallSecondArgument(object arg1, object arg2)
+        {
+            Result = arg2;
+        }
+    }
+}

--- a/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/ChangeInputArgumentAspectMethods.cs
+++ b/src/MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework/ChangeInputArgumentAspectMethods.cs
@@ -23,5 +23,11 @@ namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework
         {
             Result = arg1;
         }
+        
+        [ChangeInputArgumentsNotAllowedAspect]
+        public void InstanceMethodCallNotAllowedChangingInputArguments(object arg1)
+        {
+            Result = arg1;
+        }
     }
 }

--- a/src/MethodBoundaryAspect.Fody.sln
+++ b/src/MethodBoundaryAspect.Fody.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30503.244
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MethodBoundaryAspect.Fody", "MethodBoundaryAspect.Fody\MethodBoundaryAspect.Fody.csproj", "{30BA4684-A95A-4EC3-8EA7-CDE5B1F7E988}"
 EndProject
@@ -26,6 +26,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.External", "MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.External\MethodBoundaryAspect.Fody.UnitTests.TestAssembly.NetFramework.External.csproj", "{98C6DD8D-41E8-468B-9176-873D9DDAC82E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MethodBoundaryAspect.Fody.UnitTests.Shared", "MethodBoundaryAspect.Fody.UnitTests.Shared\MethodBoundaryAspect.Fody.UnitTests.Shared.csproj", "{4824FDD3-D225-4812-B75C-C0E455B25B7A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0C4D4E38-5A54-4A51-A308-1D4FA1AD3A4E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -84,6 +86,18 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{CBC73200-4396-409C-B950-274CB692AEF3} = {0C4D4E38-5A54-4A51-A308-1D4FA1AD3A4E}
+		{0920DE73-E0E1-4BC7-9394-5EF78D680CE9} = {0C4D4E38-5A54-4A51-A308-1D4FA1AD3A4E}
+		{744CD551-374B-4801-B565-0A008F1DD656} = {0C4D4E38-5A54-4A51-A308-1D4FA1AD3A4E}
+		{1F6B3319-7B51-418F-8E0E-77B36E26117A} = {0C4D4E38-5A54-4A51-A308-1D4FA1AD3A4E}
+		{90FD3D63-52FD-4E91-99AB-CF160876EBEB} = {0C4D4E38-5A54-4A51-A308-1D4FA1AD3A4E}
+		{145B9419-BE49-48A2-B9F9-EF32C07EDE30} = {0C4D4E38-5A54-4A51-A308-1D4FA1AD3A4E}
+		{1DD27780-A534-4DA0-9524-F09654A8DE59} = {0C4D4E38-5A54-4A51-A308-1D4FA1AD3A4E}
+		{0421F8A5-8698-4D92-9223-872FBA18572B} = {0C4D4E38-5A54-4A51-A308-1D4FA1AD3A4E}
+		{98C6DD8D-41E8-468B-9176-873D9DDAC82E} = {0C4D4E38-5A54-4A51-A308-1D4FA1AD3A4E}
+		{4824FDD3-D225-4812-B75C-C0E455B25B7A} = {0C4D4E38-5A54-4A51-A308-1D4FA1AD3A4E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EABEE29A-E6EB-4EF1-805C-34D6FF8F3E57}

--- a/src/MethodBoundaryAspect.Fody.sln.DotSettings
+++ b/src/MethodBoundaryAspect.Fody.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=parameterless/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=parameterless/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Persistable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/MethodBoundaryAspect.Fody.sln.DotSettings
+++ b/src/MethodBoundaryAspect.Fody.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Fody/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=parameterless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Persistable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/MethodBoundaryAspect.Fody/ArgumentLoadable.cs
+++ b/src/MethodBoundaryAspect.Fody/ArgumentLoadable.cs
@@ -5,9 +5,9 @@ namespace MethodBoundaryAspect.Fody
 {
     public class ArgumentLoadable : ILoadable
     {
-        int _index;
-        ParameterDefinition _parameter;
-        ILProcessor _processor;
+        private int _index;
+        private ParameterDefinition _parameter;
+        private ILProcessor _processor;
 
         public ArgumentLoadable(int i, ParameterDefinition p, ILProcessor methodProcessor)
         {

--- a/src/MethodBoundaryAspect.Fody/ArrayElementLoadable.cs
+++ b/src/MethodBoundaryAspect.Fody/ArrayElementLoadable.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace MethodBoundaryAspect.Fody
+{
+    public class ArrayElementLoadable : ILoadable
+    {
+        private readonly VariableDefinition _arrayVariableDefinition;
+        private readonly int _index;
+        private readonly ParameterDefinition _parameter;
+        private readonly ILProcessor _processor;
+
+        public ArrayElementLoadable(
+            VariableDefinition arrayVariableDefinition,
+            int index,
+            ParameterDefinition parameterDefinition,
+            ILProcessor methodProcessor)
+        {
+            _arrayVariableDefinition = arrayVariableDefinition;
+            _index = index;
+            _parameter = parameterDefinition;
+            _processor = methodProcessor;
+        }
+
+        public TypeReference PersistedType => _parameter.ParameterType;
+
+        public InstructionBlock Load(bool forDereferencing)
+        {
+            var instructions = new List<Instruction>
+            {
+                _processor.Create(OpCodes.Ldloc, _arrayVariableDefinition),
+                _processor.Create(OpCodes.Ldc_I4, _index),
+                _processor.Create(OpCodes.Ldelem_Ref)
+            };
+
+            // using "_parameter.ParameterType" won't work for generic types
+            // because in the method definition we only have the generic types, not the actual used one
+            // so casting from object to e.g. "List<T>" makes no sense.
+            // How do we get the closed generic type here for correct casting?
+            // Reproduce via executing unit tests in class "GenericClassWithArity1Tests"
+            var castOrUnbox = InstructionBlockCreator.CastValueCurrentlyOnStack(
+                _arrayVariableDefinition.VariableType.GetElementType(), // object
+                _parameter.ParameterType); // concrete type
+            instructions.AddRange(castOrUnbox);
+
+            return new InstructionBlock($"Load {_index}", instructions);
+        }
+    }
+}

--- a/src/MethodBoundaryAspect.Fody/AsyncMethodWeaver.cs
+++ b/src/MethodBoundaryAspect.Fody/AsyncMethodWeaver.cs
@@ -62,7 +62,11 @@ namespace MethodBoundaryAspect.Fody
 
         protected override void Setup() { }
 
-        protected override void HandleBody(VariableDefinition returnValue, out Instruction instructionCallStart, out Instruction instructionCallEnd)
+        protected override void HandleBody(
+            NamedInstructionBlockChain arguments,
+            VariableDefinition returnValue,
+            out Instruction instructionCallStart,
+            out Instruction instructionCallEnd)
         {
             instructionCallEnd = _ilProcessor.Body.Instructions.Last();
             if (instructionCallEnd.OpCode == OpCodes.Ret)
@@ -85,6 +89,7 @@ namespace MethodBoundaryAspect.Fody
                 chain.Prepend(_ilProcessor);
             else
                 chain.InsertAfter(_setupPointer, _ilProcessor);
+
             _setupPointer = chain.Last;
         }
 

--- a/src/MethodBoundaryAspect.Fody/AttributeFullNames.cs
+++ b/src/MethodBoundaryAspect.Fody/AttributeFullNames.cs
@@ -19,5 +19,8 @@
 
         public static string AspectOrderIndexAttribute =>
             "MethodBoundaryAspect.Fody.Attributes.AspectOrderIndexAttribute";
+
+        public static string AllowChangingInputArguments =>
+            "MethodBoundaryAspect.Fody.Attributes.AllowChangingInputArgumentsAttribute";
     }
 }

--- a/src/MethodBoundaryAspect.Fody/FieldPersistable.cs
+++ b/src/MethodBoundaryAspect.Fody/FieldPersistable.cs
@@ -1,6 +1,5 @@
 ﻿using Mono.Cecil;
 using Mono.Cecil.Cil;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -8,8 +7,7 @@ namespace MethodBoundaryAspect.Fody
 {
     public class FieldPersistable : IPersistable
     {
-        ILoadable _instance;
-        public FieldReference Field { get; private set; }
+        private readonly ILoadable _instance;
 
         public FieldPersistable(ILoadable instance, FieldReference field)
         {
@@ -17,13 +15,15 @@ namespace MethodBoundaryAspect.Fody
             Field = field;
         }
 
-        public TypeReference PersistedType { get => Field.FieldType; }
+        public FieldReference Field { get; }
+        public TypeReference PersistedType => Field.FieldType;
 
         public InstructionBlock Load(bool forDereferencing)
         {
-            return new InstructionBlock("Load",
-                _instance.Load(true).Instructions.Concat(
-                    new[] { Instruction.Create(OpCodes.Ldfld, Field) }).ToList());
+            var instructions = _instance.Load(true).Instructions
+                .Concat(new[] { Instruction.Create(OpCodes.Ldfld, Field) })
+                .ToList();
+            return new InstructionBlock("Load", instructions);
         }
 
         public InstructionBlock Store(InstructionBlock loadNewValueOntoStack, TypeReference typeOnStack)

--- a/src/MethodBoundaryAspect.Fody/InstructionBlockCreator.cs
+++ b/src/MethodBoundaryAspect.Fody/InstructionBlockCreator.cs
@@ -231,10 +231,10 @@ namespace MethodBoundaryAspect.Fody
             var parameterCount = 0;
             foreach (var argument in arguments)
             {
-                bool paramIsByRef = methodReference.Parameters[parameterCount].ParameterType.IsByReference;
+                var paramIsByRef = methodReference.Parameters[parameterCount].ParameterType.IsByReference;
 
                 loadArgumentsInstructions.AddRange(argument.Load(false).Instructions);
-                TypeReference varType = argument.PersistedType;
+                var varType = argument.PersistedType;
                 if (varType.IsByReference && !paramIsByRef)
                 {
                     varType = ((ByReferenceType)varType).ElementType;
@@ -257,8 +257,8 @@ namespace MethodBoundaryAspect.Fody
                     : OpCodes.Call,
                 methodReference);
 
-            bool methodReturnsVoid = IsVoid(methodDefinition.ReturnType);
-            bool returnValueShouldBeStored = (returnValue != null);
+            var methodReturnsVoid = IsVoid(methodDefinition.ReturnType);
+            var returnValueShouldBeStored = (returnValue != null);
 
             List<Instruction> HandleReturnValue(List<Instruction> methodWork)
             {
@@ -295,15 +295,16 @@ namespace MethodBoundaryAspect.Fody
             return HandleReturnValue(instructions);
         }
 
-        private static IEnumerable<Instruction> CastValueCurrentlyOnStack(TypeReference fromType, TypeReference toType)
+        public static IEnumerable<Instruction> CastValueCurrentlyOnStack(TypeReference fromType, TypeReference toType)
         {
             if (fromType.Equals(toType) || fromType.FullName.Equals(toType.FullName))
-                return new Instruction[0];
+                return Enumerable.Empty<Instruction>();
 
-            if (fromType.FullName == typeof(Object).FullName)
+            if (fromType.FullName == typeof(object).FullName)
             {
                 if (toType.IsValueType || toType.IsGenericParameter)
                     return new[] { Instruction.Create(OpCodes.Unbox_Any, toType) };
+                
                 return new[] { Instruction.Create(OpCodes.Castclass, toType) };
             }
 
@@ -325,9 +326,9 @@ namespace MethodBoundaryAspect.Fody
                     _processor.Create(OpCodes.Stloc, array)
                 };
 
-                OpCode stelem = elementType.GetStElemCode();
+                var stelem = elementType.GetStElemCode();
 
-                for (int i = 0; i < args.Length; ++i)
+                for (var i = 0; i < args.Length; ++i)
                 {
                     var parameter = args[i];
                     createArrayInstructions.Add(_processor.Create(OpCodes.Ldloc, array));
@@ -371,7 +372,7 @@ namespace MethodBoundaryAspect.Fody
                 var valueType = arg.Type;
                 if (arg.Value is TypeReference)
                     valueType = _referenceFinder.GetTypeReference(typeof(Type));
-                bool isEnum = valueType.IsEnum(out _);
+                var isEnum = valueType.IsEnum(out _);
                 valueType = valueType.CleanEnumsInTypeRef();
                 var instructions = LoadValueOnStack(valueType, arg.Value);
                 if (valueType.IsValueType || (!valueType.IsArray && isEnum))
@@ -403,7 +404,7 @@ namespace MethodBoundaryAspect.Fody
                 case MetadataType.UInt32:
                     return new[] { _processor.Create(OpCodes.Ldc_I4, (int)(uint)value) };
                 case MetadataType.Int64:
-                    long longVal = (long)value;
+                    var longVal = (long)value;
                     if (longVal <= Int32.MaxValue && longVal >= Int32.MinValue)
                         return new[]
                         {
@@ -412,7 +413,7 @@ namespace MethodBoundaryAspect.Fody
                         };
                     return new[] { _processor.Create(OpCodes.Ldc_I8, longVal) };
                 case MetadataType.UInt64:
-                    ulong ulongVal = (ulong)value;
+                    var ulongVal = (ulong)value;
                     if (ulongVal <= Int32.MaxValue)
                         return new[]
                         {

--- a/src/MethodBoundaryAspect.Fody/MethodWeaver.cs
+++ b/src/MethodBoundaryAspect.Fody/MethodWeaver.cs
@@ -278,7 +278,7 @@ namespace MethodBoundaryAspect.Fody
 
             // get arguments from ExecutionArgs because they could have been changed in aspect code
             var args = _method.Parameters
-                .Select((x,i) => new ArrayElementLoadable(arguments.Variable, i, x, _method.Body.GetILProcessor()))
+                .Select((x,i) => new ArrayElementLoadable(arguments.Variable, i, x, _method.Body.GetILProcessor(), _creator))
                 .Cast<ILoadable>()
                 .ToArray();
 

--- a/src/MethodBoundaryAspect.Fody/MethodWeaver.cs
+++ b/src/MethodBoundaryAspect.Fody/MethodWeaver.cs
@@ -52,7 +52,7 @@ namespace MethodBoundaryAspect.Fody
 
             WeaveOnEntry(returnValue);
             
-            HandleBody(returnValue?.Variable, out var instructionCallStart, out var instructionCallEnd);
+            HandleBody(arguments, returnValue?.Variable, out var instructionCallStart, out var instructionCallEnd);
 
             var instructionAfterCall = WeaveOnExit(hasReturnValue, returnValue);
 
@@ -262,7 +262,11 @@ namespace MethodBoundaryAspect.Fody
             }
         }
         
-        protected virtual void HandleBody(VariableDefinition returnValue, out Instruction instructionCallStart, out Instruction instructionCallEnd)
+        protected virtual void HandleBody(
+            NamedInstructionBlockChain arguments,
+            VariableDefinition returnValue,
+            out Instruction instructionCallStart,
+            out Instruction instructionCallEnd)
         {
             VariableDefinition thisVariable = null;
             if (!_method.IsStatic)
@@ -272,11 +276,23 @@ namespace MethodBoundaryAspect.Fody
                 thisVariable = thisVariableBlock.Variable;
             }
 
-            var callSourceMethod = _creator.CallMethodWithLocalParameters(
-                _method,
+            // get arguments from ExecutionArgs because they could have been changed in aspect code
+            var args = _method.Parameters
+                .Select((x,i) => new ArrayElementLoadable(arguments.Variable, i, x, _method.Body.GetILProcessor()))
+                .Cast<ILoadable>()
+                .ToArray();
+
+            var callSourceMethod = _creator.CallMethodWithReturn(
                 _clonedMethod,
                 thisVariable == null ? null : new VariablePersistable(thisVariable),
-                returnValue == null ? null : new VariablePersistable(returnValue));
+                returnValue == null ? null : new VariablePersistable(returnValue),
+                args);
+
+            ////var callSourceMethod = _creator.CallMethodWithLocalParameters(
+            ////    _method,
+            ////    _clonedMethod,
+            ////    thisVariable == null ? null : new VariablePersistable(thisVariable),
+            ////    returnValue == null ? null : new VariablePersistable(returnValue));
             callSourceMethod.Append(_ilProcessor);
             instructionCallStart = callSourceMethod.First;
             instructionCallEnd = callSourceMethod.Last;

--- a/src/MethodBoundaryAspect.Fody/MethodWeaverLogic.cs
+++ b/src/MethodBoundaryAspect.Fody/MethodWeaverLogic.cs
@@ -29,7 +29,7 @@ namespace MethodBoundaryAspect.Fody
 
         //    try
         //    {
-        //        var returnValue = OriginalMethod(param1, param2, param3);
+        //        var returnValue = OriginalMethod(args[0], args[1], args[2]);
         //        methodExecutionArgs.ReturnValue = returnValue;
         //    }
         //    catch (Exception ex)

--- a/src/MethodBoundaryAspect.Fody/Ordering/AspectInfo.cs
+++ b/src/MethodBoundaryAspect.Fody/Ordering/AspectInfo.cs
@@ -26,15 +26,16 @@ namespace MethodBoundaryAspect.Fody.Ordering
             InitOrder(aspectAttributes);
             InitSkipProperties(aspectAttributes);
             InitTargetMembers();
+            InitChangingInputArguments(aspectAttributes);
         }
-        
+
         public TypeDefinition AspectTypeDefinition { get; }
 
         public string Name { get; private set; }
 
         public string Role { get; private set; }
 
-        public bool SkipProperties { get; set; }
+        public bool SkipProperties { get; private set; }
 
         public CustomAttribute AspectAttribute { get; private set; }
 
@@ -44,7 +45,9 @@ namespace MethodBoundaryAspect.Fody.Ordering
         public AspectOrder Order { get; private set; }
 #pragma warning restore 0618
 
-        public int? OrderIndex { get; set; }
+        public int? OrderIndex { get; private set; }
+
+        public bool AllowChangingInputArguments { get; private set; }
 
         public IEnumerable<MethodAttributes> AttributeTargetMemberAttributes { get; set; } =
             new List<MethodAttributes>
@@ -188,6 +191,13 @@ namespace MethodBoundaryAspect.Fody.Ordering
             }
 
             AttributeTargetMemberAttributes = memberAttributes;
+        }
+
+        private void InitChangingInputArguments(IEnumerable<CustomAttribute> aspectAttributes)
+        {
+            AllowChangingInputArguments = aspectAttributes
+                .Any(c => c.AttributeType.FullName == AttributeFullNames.AllowChangingInputArguments);
+
         }
     }
 }

--- a/src/MethodBoundaryAspect.Fody/ReferenceExtensions.cs
+++ b/src/MethodBoundaryAspect.Fody/ReferenceExtensions.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Mono.Cecil;
-using Mono.Cecil.Rocks;
 
 namespace MethodBoundaryAspect.Fody
 {
@@ -23,8 +20,7 @@ namespace MethodBoundaryAspect.Fody
 
         public static MethodReference MakeGeneric (this MethodReference self, params TypeReference [] arguments)
         {
-            MethodReference baseReference = self.DeclaringType.Module.ImportReference(self);
-
+            var baseReference = self.DeclaringType.Module.ImportReference(self);
             var reference = new GenericInstanceMethod(baseReference);
             
             foreach (var genericParameter in baseReference.GenericParameters)

--- a/src/MethodBoundaryAspect.Fody/VariablePersistable.cs
+++ b/src/MethodBoundaryAspect.Fody/VariablePersistable.cs
@@ -1,23 +1,26 @@
 ﻿using Mono.Cecil;
 using Mono.Cecil.Cil;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace MethodBoundaryAspect.Fody
 {
     public class VariablePersistable : IPersistable
     {
-        VariableDefinition _def;
+        private VariableDefinition _def;
 
         public VariablePersistable(VariableDefinition def)
         {
             _def = def;
         }
 
+        public TypeReference PersistedType => _def.VariableType;
+
         public InstructionBlock Load(bool forDereferencing)
         {
-            return new InstructionBlock("Load", Instruction.Create(
-                _def.VariableType.IsValueType && forDereferencing ? OpCodes.Ldloca : OpCodes.Ldloc, _def));
+            var opCode = _def.VariableType.IsValueType && forDereferencing
+                ? OpCodes.Ldloca 
+                : OpCodes.Ldloc;
+            return new InstructionBlock("Load", Instruction.Create(opCode, _def));
         }
 
         public InstructionBlock Store(InstructionBlock loadNewValueOntoStack, TypeReference typeOnStack)
@@ -39,7 +42,5 @@ namespace MethodBoundaryAspect.Fody
             list.Add(postInstruction);
             return new InstructionBlock("Store", list);
         }
-
-        public TypeReference PersistedType { get => _def.VariableType; }
     }
 }

--- a/src/MethodBoundaryAspect/Attributes/AllowChangingInputArgumentsAttribute.cs
+++ b/src/MethodBoundaryAspect/Attributes/AllowChangingInputArgumentsAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace MethodBoundaryAspect.Fody.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class AllowChangingInputArgumentsAttribute : Attribute
+    {
+    }
+}

--- a/src/MethodBoundaryAspect/Attributes/MethodExecutionArgs.cs
+++ b/src/MethodBoundaryAspect/Attributes/MethodExecutionArgs.cs
@@ -3,14 +3,49 @@ using System.Reflection;
 
 namespace MethodBoundaryAspect.Fody.Attributes
 {
+    /// <summary>
+    /// This class contains various information about method boundary context 
+    /// </summary>
     public class MethodExecutionArgs
     {
+        /// <summary>
+        /// This property defines the behavior after the aspect method calls.
+        /// </summary>
         public FlowBehavior FlowBehavior { get; set; }
+
+        /// <summary>
+        /// This property contains the instance of the called method.
+        /// If a static method is called this property is NULL
+        /// </summary>
         public object Instance { get; set; }
+
+        /// <summary>
+        /// This property contains the method information of the called method.
+        /// </summary>
         public MethodBase Method { get; set; }
+
+        /// <summary>
+        /// This property contains the input arguments of the current method call.
+        /// If the aspect has the "AllowChangingInputArgumentsAttribute" attribute the aspect can modify
+        /// these values. The modified values will then be forwarded to the real method call.
+        /// </summary>
         public object[] Arguments { get; set; }
+
+        /// <summary>
+        /// This property will be used as the return value for the current method call.
+        /// This property can be modified in the aspect.
+        /// </summary>
         public object ReturnValue { get; set; }
+
+        /// <summary>
+        /// This property contains the exception object if an exception was thrown in the real method call.
+        /// </summary>
         public Exception Exception { get; set; }
+
+        /// <summary>
+        /// This property can be used to store any data over the lifetime of the method call.
+        /// E.g. store an id in "OnEntry()" and use it in the "OnExit()" method call
+        /// </summary>
         public object MethodExecutionTag { get; set; }
     }
 }


### PR DESCRIPTION
Implementation almost done.
Remaining problem is that the args array from the MethodExecutionArgs has to be casted/unboxed back from object.
For non-generic types this works because the parameter definitions of the method matches the argument types. But for generic types the parameter definition only contains the open types. We need to get the closed generic types for correct cast.

