### PR TITLE
removed obsolete logging methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Rider files
+.idea/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/src/MethodBoundaryAspect.Fody/ModuleWeaver.cs
+++ b/src/MethodBoundaryAspect.Fody/ModuleWeaver.cs
@@ -37,7 +37,6 @@ namespace MethodBoundaryAspect.Fody
 
         public ModuleWeaver()
         {
-            InitLogging();
         }
 
         public bool DisableCompileTimeMethodInfos { get; set; }
@@ -130,16 +129,6 @@ namespace MethodBoundaryAspect.Fody
         public void AddPropertyFilter(string propertyFilter)
         {
             PropertyFilter.Add(propertyFilter);
-        }
-
-        private void InitLogging()
-        {
-            LogDebug = m => Debug.WriteLine(m);
-            LogInfo = LogDebug;
-            LogWarning = LogDebug;
-            LogWarningPoint = (m, p) => { };
-            LogError = LogDebug;
-            LogErrorPoint = (m, p) => { };
         }
 
         private void Execute(ModuleDefinition module)


### PR DESCRIPTION
these methods are obsolete in the updated version of fody. See: https://github.com/Fody/Fody/issues/804

I could not find where you called 'log' anywhere, so i simply removed these methods.  

All tests pass... but this should be reviewed because im not sure what the purpose of the logging delegates were in the first place, because they were never used from what i could see