### PR TITLE
include netstandard 2.1 as target framework

### DIFF
--- a/src/MethodBoundaryAspect.Fody/MethodBoundaryAspect.Fody.csproj
+++ b/src/MethodBoundaryAspect.Fody/MethodBoundaryAspect.Fody.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
       
   <ItemGroup>

--- a/src/MethodBoundaryAspect/MethodBoundaryAspect.csproj
+++ b/src/MethodBoundaryAspect/MethodBoundaryAspect.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>  
 
   <PropertyGroup>


### PR DESCRIPTION
When working on a project which uses netstandard 2.1 libraries and adding an aspect created with the MethodBoundaryAspect, this causes hot reload (when using dotnet watch) to fail.

_CS7038 Failed to emit module 'project name': Changing the version of an assembly reference is not allowed during debugging: 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' changed version to '2.1.0.0'._

While it doesn't stop the project from running it is annoying as you then have to restart the project to pick up even the simplest change (e.g. css/html markup)

I've tested by updating the TargetFrameworks to include netstandard 2.1 and it resolves the issue.